### PR TITLE
[golinks] introduce '+' handling

### DIFF
--- a/handlers/index.go
+++ b/handlers/index.go
@@ -12,7 +12,6 @@ type Index struct {
 	Template *template.Template
 }
 
-var defaultIndexPath = "static/templates/index.tmpl"
 var searchPath = "static/templates/search.tmpl"
 
 func NewIndex(path string) (Index, error) {

--- a/handlers/shortInfo.go
+++ b/handlers/shortInfo.go
@@ -1,0 +1,33 @@
+package handlers
+
+import (
+	"html/template"
+	"log"
+	"net/http"
+)
+
+type ShortInfo struct {
+	Short    string
+	Long     string
+	Error    string
+	Template *template.Template
+}
+
+var shortInfoTemplatePath = "static/templates/existing.tmpl"
+
+func NewShortInfo() (ShortInfo, error) {
+	t, err := template.ParseFiles(shortInfoTemplatePath)
+	if err != nil {
+		return ShortInfo{}, err
+	}
+
+	return ShortInfo{Template: t}, nil
+}
+
+func (i ShortInfo) ServeShortInfoHTTP(w http.ResponseWriter, r *http.Request) {
+	err := i.Template.Execute(w, i)
+	if err != nil {
+		http.Error(w, err.Error(), http.StatusInternalServerError)
+		log.Println(err)
+	}
+}

--- a/handlers/utils.go
+++ b/handlers/utils.go
@@ -3,7 +3,23 @@ package handlers
 import (
 	"fmt"
 	"net/http"
+	"strings"
 )
+
+const (
+	INFO_SUFFIX = "+"
+)
+
+func isInfoShort(short string) bool {
+	if strings.HasSuffix(short, INFO_SUFFIX) {
+		return true
+	}
+	return false
+}
+
+func shortFromInfoShort(short string) string {
+	return strings.TrimSuffix(short, INFO_SUFFIX)
+}
 
 func getShortFromRequest(r *http.Request) (short string, err error) {
 	if short := r.URL.Path[1:]; len(short) > 0 {

--- a/static/templates/existing.tmpl
+++ b/static/templates/existing.tmpl
@@ -1,0 +1,69 @@
+{{define "existing"}}
+<!doctype html>
+<html lang="en">
+<head>
+    <meta charset="utf-8">
+    <meta http-equiv="X-UA-Compatible" content="IE=edge,chrome=1">
+    <link rel="shortcut icon" href="/img/favicon.ico" />
+    <title>Go Shorten Things!</title>
+    <meta name="description" content="">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+    <link rel="stylesheet" href="/css/fontawesome-all.min.css">
+    <link rel="stylesheet" href="/css/milligram.min.css">
+    <link rel="stylesheet" href="/css/shorten.css">
+</head>
+
+<body>
+<h1>{{.Short}}</h1>
+<main class="wrapper">
+    <section>
+    <div id="error-message" class="alert alert-danger">
+        {{- if .Error}}{{.Error}}{{end -}}
+    </div>
+    </section>
+
+    The golink <em><a href="{{.Long}}">{{.Short}}</a></em> points to the url  {{.Long}} <!-- and has count Count -->
+    <section class="container create-short">
+        <form id="shorten-form" action="/" method="POST">
+            <div class="row">
+                <div class="column send-column">
+                    <h4>Send</h4>
+                </div>
+                <div class="column go-column">
+                    <label for="code">go/</label>
+                </div>
+                <div class="column column-25 code-column">
+                    <input id="code" name="code" type="text" class="form-control"{{if .Short -}} value="{{.Short}}" {{- else -}} placeholder="Enter short url..." autofocus {{- end}} required>
+                </div>
+                <div class="column collapse-padding to-column">
+                    <label for="url">to</label>
+                </div>
+                <div class="column column-50 url-column">
+                    <input id="url" name="url" type="url" class="form-control" placeholder="Enter long url...">
+                </div>
+                <div class="column column-10 button-column">
+                    <button id="shortenButton" class="large-button" type="submit">Shorten!</button>
+                </div>
+                {{if .Short -}}
+                    <div class="column column-10 button-column">
+                        <a id="search-button" class="button" href="#">Search for {{.Short}}</a>
+                    </div>
+                {{- end}}
+            </div>
+        </form>
+    </section>
+    <section id="link-container" class="container short-link">
+        <div class="row">
+            <div class="centered">
+                <h1>
+                    <a id="link" href="#"></a>
+                </h1>
+            </div>
+        </div>
+    </section>
+</main>
+<script src="/js/app.js"></script>
+</body>
+</html>
+{{end}}
+{{template "existing" .}}


### PR DESCRIPTION
In typical shorturl installations it possible to append a '+' to the URL
and see what the URL is along with any metadata associated with it.

While the current routing mechanism makes this difficult, begin the
introduction

This was tested manually as I could not determine any existing test
infrastructure for the web framework.
<img width="1353" alt="image" src="https://user-images.githubusercontent.com/433817/235049503-e5770aa4-1d92-40a6-8808-22bee5441851.png">

